### PR TITLE
Implement 1v1 and 2v2 leaderboards and update player handling

### DIFF
--- a/migrations/create_tables.sql
+++ b/migrations/create_tables.sql
@@ -1,0 +1,34 @@
+-- Migration script to create separate 1v1 and 2v2 tables
+-- Run this script in your PostgreSQL database
+
+-- Create 1v1 table
+CREATE TABLE IF NOT EXISTS rocketleague_1v1 (
+    "id" SERIAL PRIMARY KEY,
+    "Name" VARCHAR(255) NOT NULL,
+    "MMR" DOUBLE PRECISION NOT NULL DEFAULT 1000,
+    "Wins" INTEGER NOT NULL DEFAULT 0,
+    "Losses" INTEGER NOT NULL DEFAULT 0,
+    "MatchUID" UUID,
+    "DiscordId" INTEGER UNIQUE NOT NULL
+);
+
+-- Create 2v2 table
+CREATE TABLE IF NOT EXISTS rocketleague_2v2 (
+    "id" SERIAL PRIMARY KEY,
+    "Name" VARCHAR(255) NOT NULL,
+    "MMR" DOUBLE PRECISION NOT NULL DEFAULT 1000,
+    "Wins" INTEGER NOT NULL DEFAULT 0,
+    "Losses" INTEGER NOT NULL DEFAULT 0,
+    "MatchUID" UUID,
+    "DiscordId" INTEGER UNIQUE NOT NULL
+);
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_rocketleague_1v1_discordid ON rocketleague_1v1("DiscordId");
+CREATE INDEX IF NOT EXISTS idx_rocketleague_1v1_mmr ON rocketleague_1v1("MMR" DESC);
+CREATE INDEX IF NOT EXISTS idx_rocketleague_2v2_discordid ON rocketleague_2v2("DiscordId");
+CREATE INDEX IF NOT EXISTS idx_rocketleague_2v2_mmr ON rocketleague_2v2("MMR" DESC);
+
+-- Note: After running this script, you can manually delete the old 'rocketleague' table:
+-- DROP TABLE IF EXISTS rocketleague;
+

--- a/src/main.go
+++ b/src/main.go
@@ -19,6 +19,8 @@ import (
 var Token string
 var tokenApi string
 var playerRepository *interfaces.PlayerRepo
+var playerRepo1v1 *interfaces.PlayerRepo
+var playerRepo2v2 *interfaces.PlayerRepo
 var matchRepository *interfaces.MatchRepo
 
 func init() {
@@ -40,11 +42,16 @@ func init() {
 
 	tokenApi = os.Getenv("POSTGRES_CONNECTION_STRING")
 
-	// Data Initialization
-	playerRepoHandler := infrastructure.NewPlayerHandler(tokenApi)
+	// Data Initialization - separate handlers for 1v1 and 2v2 tables
+	playerRepoHandler1v1 := infrastructure.NewPlayerHandler(tokenApi, "rocketleague_1v1")
+	playerRepoHandler2v2 := infrastructure.NewPlayerHandler(tokenApi, "rocketleague_2v2")
 	matchRepoHandler := infrastructure.NewMatchHandler()
-	playerRepository = interfaces.NewPlayerRepo(playerRepoHandler)
+	playerRepo1v1 = interfaces.NewPlayerRepo(playerRepoHandler1v1)
+	playerRepo2v2 = interfaces.NewPlayerRepo(playerRepoHandler2v2)
 	matchRepository = interfaces.NewMatchDataRepo(matchRepoHandler)
+
+	// Keep old variable for backward compatibility (will use 2v2)
+	playerRepository = playerRepo2v2
 
 }
 
@@ -57,7 +64,7 @@ func main() {
 
 	// Create application bot delegator
 	// Register handler Function
-	d := application.NewDelegator(playerRepository, matchRepository)
+	d := application.NewDelegator(playerRepo1v1, playerRepo2v2, matchRepository)
 
 	clientConnection.AddHandler(d.InitiateDelegator)
 


### PR DESCRIPTION
- Added separate player repositories for 1v1 and 2v2 match types.
- Enhanced API to support distinct leaderboard endpoints for 1v1 and 2v2.
- Updated player handling logic to accommodate new match types, including queue management and player retrieval.
- Maintained backward compatibility by defaulting to 2v2 where necessary.